### PR TITLE
chore: Update contributors-readme-action to v2.3.10

### DIFF
--- a/.github/workflows/contrib-readme.yml
+++ b/.github/workflows/contrib-readme.yml
@@ -14,14 +14,14 @@ jobs:
     name: A job to automate contrib in readme
     steps:
       - name: Update README.md
-        uses: akhilmhdh/contributors-readme-action@v2.3.6
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
         with:
           readme_path: "README.md"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update README.zh-CN.md
-        uses: akhilmhdh/contributors-readme-action@v2.3.6
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
         with:
           readme_path: "README.zh-CN.md"
         env:


### PR DESCRIPTION
update the version of contributors-readme-action to fix the Null Name in README.md and README.zh-CN.md

ref: [Fix null name, no capitalize & introduce eslint fix command](https://github.com/akhilmhdh/contributors-readme-action/pull/77)